### PR TITLE
herokuへのデプロイに伴う設定を追加

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
-    %title App
+    %title ActiveReader
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'

--- a/config/database.yml
+++ b/config/database.yml
@@ -49,6 +49,6 @@ test:
 #
 production:
   <<: *default
-  database: app_production
-  username: app
-  password: <%= ENV['APP_DATABASE_PASSWORD'] %>
+  database: <%= ENV.fetch('DB_NAME') %>
+  username: <%= ENV.fetch('DB_USERNAME') %>
+  password: <%= ENV.fetch('DB_PASSWORD') %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
## What
Herokuへデプロイする際に、各種設定を一部修正しました。

## Why
本番環境でアプリケーションを正しく動作させるため。

## 今回保留した作業と今後のTODO
- CircleCIを用いたCI/CDパイプラインの構築
- 本番環境での動作検証
- （必要であれば）Dockerfile, docker-compose.ymlの修正

## 備考（実装にあたって参考にした情報など）
- [【初心者向け】railsアプリをherokuを使って確実にデプロイする方法【決定版】](https://qiita.com/kazukimatsumoto/items/a0daa7281a3948701c39)
- [Heroku Container Registryで作るDocker時代のRails 5 入門](https://qiita.com/koduki/items/3aafc38c6c518bef2af3#heroku上のアプリをproductionモードにする)
- [DockerでRails環境構築 + CircleCIで自動テストとherokuへの自動デプロイを実行](https://qiita.com/kei_f_1996/items/934296e23b0d8d877ff1)
- [HerokuにRailsアプリのDockerコンテナをプッシュするまで(MySQL 5.7)](https://github.com/t-krt/ActiveReader/compare/setting-for-heroku?expand=1)