### PR TITLE
レーティング機能の修正

### DIFF
--- a/app/assets/javascripts/changeRate.js
+++ b/app/assets/javascripts/changeRate.js
@@ -1,0 +1,11 @@
+$(document).on("turbolinks:load", function() {
+  let ratingScore = $('#star').data("rating-score");
+
+  $('#star').raty({
+    size: 36,
+    starOff:  image_path('star-off.png'),
+    starOn : image_path('star-on.png'),
+    scoreName: 'review[rate]',
+    score: ratingScore
+  });
+});

--- a/app/assets/javascripts/imageUrl.js.erb
+++ b/app/assets/javascripts/imageUrl.js.erb
@@ -1,0 +1,13 @@
+<%
+  imgs = {}
+  Dir.chdir("#{Rails.root}/app/assets/images/") do
+    imgs = Dir["**/*"].inject({}) do |h,f|
+      h.merge!(f => image_path(f)) unless Dir.exist? f
+      h
+    end
+  end
+%>
+
+window.image_path = function(name){
+  return <%= imgs.to_json %>[name];
+}

--- a/app/assets/javascripts/readRate.js
+++ b/app/assets/javascripts/readRate.js
@@ -1,0 +1,15 @@
+$(document).on("turbolinks:load", function() {
+  $('.read-only-rate').each(function(){
+    let rateId = $(this).data("rated-star-id");
+    let rateScore = $(this).data("rated-star-score");
+
+    $(`#star-rate-${rateId}`).raty({
+      size: 36,
+      starOff:  image_path('star-off.png'),
+      starOn : image_path('star-on.png'),
+      starHalf: image_path('star-half.png'),
+      readOnly: true,
+      score: rateScore
+    });
+  });
+});

--- a/app/assets/javascripts/textarea_height.js
+++ b/app/assets/javascripts/textarea_height.js
@@ -1,10 +1,8 @@
 $(document).on("ready turbolinks:load", function() {
-  $(function() {
-    var $textarea = $('.textarea');
-    var lineHeight = parseInt($textarea.css('lineHeight'));
-    $textarea.on('input', function(e) {
-      var lines = ($(this).val() + '\n').match(/\n/g).length;
-      $(this).height(lineHeight * lines);
-    });
+  let $textarea = $('.textarea');
+  let lineHeight = parseInt($textarea.css('lineHeight'));
+  $textarea.on('input', function(e) {
+    var lines = ($(this).val() + '\n').match(/\n/g).length;
+    $(this).height(lineHeight * lines);
   });
 });

--- a/app/views/reviews/_form.html.haml
+++ b/app/views/reviews/_form.html.haml
@@ -34,18 +34,8 @@
     .form-group.row.review-body__content
       = review.label :読書メモ, class: "col-sm-2 col-form-label badge-info"
       = review.text_area :note, class: 'form-control textarea'
-    #star.form-group.row.review-body__content
+    #star.form-group.row.review-body__content{"data-rating-score": @review.rate}
       = review.label :評価, class: "col-sm-2 col-form-label badge-info star-label"
-      = review.hidden_field :rate, id: 'review_star', class: 'form-control col-sm-2', value: 1, max: 5, min: 1
+      = review.hidden_field :rate, id: 'rating-star', class: 'form-control col-sm-2', value: 1, max: 5, min: 1
   .form-group.review-submit
     = book.submit "登録する", class: 'btn btn-primary'
-
-:erb
-  <script>
-    $('#star').raty({
-      size: 36,
-      starOff: '<%= asset_path('star-off.png') %>',
-      starOn : '<%= asset_path('star-on.png') %>',
-      scoreName: 'review[rate]'
-    });
-  </script>

--- a/app/views/reviews/_review.html.haml
+++ b/app/views/reviews/_review.html.haml
@@ -20,7 +20,7 @@
           = review.user.nickname
           さん
         - if review.rate.present?
-          .user-info__right__others--rate.rate{id: "star-rate-#{review.id}"}
+          .user-info__right__others--rate.rate.read-only-rate{id: "star-rate-#{review.id}",  "data-rated-star": {"id": review.id, "score": review.rate}}
         - else
           .user-info__right__others--rate.rate 未評価
 
@@ -41,15 +41,3 @@
                                   image_url: review.book.image_url, url: review.book.url, isbn: review.book.isbn),
                                   class: "badge badge-info"
           = link_to "本の詳細を見る", "#{review.book.url}", class: "badge badge-info"
-
-:erb
-  <script>
-    $('#star-rate-<%= review.id %>').raty({
-      size: 36,
-      starOff:  '<%= asset_path('star-off.png') %>',
-      starOn : '<%= asset_path('star-on.png') %>',
-      starHalf: '<%= asset_path('star-half.png') %>',
-      readOnly: true,
-      score: <%= review.rate %>,
-    });
-  </script>

--- a/app/views/reviews/new.html.haml
+++ b/app/views/reviews/new.html.haml
@@ -1,6 +1,4 @@
 .container.review-form
-  .flash
-    = render partial: "shared/notification"
   %h2
     新規登録
   .review-header

--- a/app/views/reviews/show.html.haml
+++ b/app/views/reviews/show.html.haml
@@ -19,7 +19,10 @@
           .badge.badge-info.badge-pill
             登録日
           = @review.created_at.strftime("%Y/%m/%d")
-        .rate{id: "star-rate-#{@review.id}"}
+        - if @review.rate.present?
+          .rate.read-only-rate{id: "star-rate-#{@review.id}",  "data-rated-star": {"id": @review.id, "score": @review.rate}}
+        - else
+          .rate 未評価
         .wrapper-book-info__icon.float-right
           - if user_signed_in? && @review.user_id == current_user.id
             = link_to edit_review_path(@review) do
@@ -56,15 +59,3 @@
           %span.wrapper-book-info--notice （※あなたにしか見えていません）
         .card-body.review-show__contents__list 
           = render 'shared/task-list-all'
-:erb
-  <script>
-    $('#star-rate-<%= @review.id %>').raty({
-      size: 36,
-      starOff:  '<%= asset_path('star-off.png') %>',
-      starOn : '<%= asset_path('star-on.png') %>',
-      starHalf: '<%= asset_path('star-half.png') %>',
-      readOnly: true,
-      score: <%= @review.rate %>
-    });
-  </script>
-  

--- a/app/views/users/_book-lists.html.haml
+++ b/app/views/users/_book-lists.html.haml
@@ -17,16 +17,7 @@
         = link_to review_path(reviewed_book) do
           = reviewed_book.book.title.truncate(35)
     .card-text
-      .rate{id: "star-rate-#{reviewed_book.id}"}
-
-:erb
-  <script>
-    $('#star-rate-<%= reviewed_book.id %>').raty({
-      size: 36,
-      starOff:  '<%= asset_path('star-off.png') %>',
-      starOn : '<%= asset_path('star-on.png') %>',
-      starHalf: '<%= asset_path('star-half.png') %>',
-      readOnly: true,
-      score: <%= reviewed_book.rate %>,
-    });
-  </script>
+      - if reviewed_book.rate.present? 
+        .rate.read-only-rate{id: "star-rate-#{reviewed_book.id}", "data-rated-star": {"id": reviewed_book.id, "score": reviewed_book.rate}}
+      - else
+        .rate 未評価


### PR DESCRIPTION
## What
レーティング情報の表示に関するコードを全体的に修正しました。

## Why
それぞれのviewファイルに直接JSの処理を記述しており、可読性・保守性が低い状態であったため。

## 今回保留した作業と今後のTODO
ブラウザバック時に、レーティングの画像が二重に表示されてしまう問題への対応（イシュー#30）

## 備考（実装にあたって参考にした情報など）
- [ratyのGithub](https://github.com/wbotelhos/raty)
- [image_pathをJavaScript側から使う](https://qiita.com/jkr_2255/items/c922099876b832e66969)
- [カスタムデータ属性（data-*）の値に複数設定、それを取得する方法](https://qiita.com/yamanoku/items/9459bec5413be46afcda)
