### PR TITLE
Gemfile.lockのアップデート

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.13.1)
       sexp_processor (~> 4.9)
-    rubyzip (1.2.3)
+    rubyzip (1.3.0)
     sassc (2.0.1)
       ffi (~> 1.9)
       rake


### PR DESCRIPTION
##  What
gem 'rubyzip'のバージョンをアップデートしました。

## Why
githubのセキュリティアラートに対応するため。

## How
`bundle update rubyzip`を実行しました。