### PR TITLE
production.rbの修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
## What
uglifierに関する記述を一部修正しました。

## Why
JSファイルで利用しているES6記法に対応するため。

## 備考（実装にあたって参考にした情報など）
- [Uglifier Github](https://github.com/lautis/uglifier#es6--es2015--harmony-mode)
- [RailsでES6の機能を使うとプリコンパイルが通らない（Uglifierがエラーを吐く）問題
](https://qiita.com/Thort/items/18c44604aba65303c221)
- Uglifier :arrow_right: JavaScriptを圧縮（コードの改行や空白を削除して軽量化）する役割を持つ？