### PR TITLE
他人の投稿を編集・削除できないように対策を追加

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,4 +1,6 @@
 class BooksController < ApplicationController
+  before_action :authenticate_user!
+  
   def search
     @books = []
     @details = []

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,6 +1,6 @@
 class BooksController < ApplicationController
   before_action :authenticate_user!
-  
+
   def search
     @books = []
     @details = []

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,6 +2,7 @@ class TasksController < ApplicationController
   before_action :authenticate_user!
   before_action :set_task, only: %i[edit update destroy finish]
   before_action :set_review, only: %i[new edit]
+  before_action :owenr_equal_current_user?, only: %i[edit update destroy]
 
   def index
     @reviews = Review.with_book.desc.where(user_id: current_user.id).page(params[:page]).per(5)
@@ -63,5 +64,9 @@ class TasksController < ApplicationController
 
   def set_review
     @review = Review.find(params[:review_id])
+  end
+
+  def owenr_equal_current_user?
+    redirect_to reading_user_path(current_user) unless @task.review.user_id == current_user.id
   end
 end


### PR DESCRIPTION
## What
他人が登録したレビューやタスクを編集・更新・削除できないように修正しました。

## Why
イシュー[#71](https://github.com/t-krt/ActiveReader/issues/71)への対応のため。

## How
Controllerで登録者と現在ログインしているユーザーが一致しているかを判別し、
一致していない場合は、マイページトップへリダイレクトさせるようにしました。