### PR TITLE
ユーザー削除機能の仕様を修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -20,9 +20,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # PUT /resource
-  # def update
-  #   super
-  # end
+  def update
+    # ポートフォリオ閲覧用ユーザーの情報が編集されないよう対応
+    if current_user.email == "guest-user@guest.com"
+      redirect_to reading_user_path(current_user)
+      flash[:notice] = 'ポートフォリオ閲覧用ユーザーの情報は編集できません'
+    else
+      super
+    end
+  end
 
   # DELETE /resource
   def destroy

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -27,7 +27,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # DELETE /resource
   def destroy
     # ポートフォリオ閲覧用ユーザーが削除されないよう対応
-    if current_user.id == 1
+    if current_user.email == "guest-user@guest.com"
       redirect_to reading_user_path(current_user)
       flash[:notice] = 'ポートフォリオ閲覧用ユーザーは削除できません'
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   mount_uploader :avatar, AvatarUploader
 
-  has_many :reviews, dependent: :delete_all
+  has_many :reviews, dependent: :destroy
   validates :nickname, presence: true, uniqueness: true
 end


### PR DESCRIPTION
## What
ユーザーが孫関係にあるTaskを所有している場合でも、アカウント削除できるようにしました。
また、テストユーザーの判別条件を変更し、テストユーザーである場合は、編集・削除ができないようにしました。

## Why
ユーザーがタスクを所有している場合に、アカウント削除ができなかったため。

## How
user.rbで、has_many関係にあるReviewモデルとのアソシエーションのオプションとして`dependent: :delete_all`を指定していたのが原因たったため、オプションを`dependent: :destroy`に修正しました。
delete_allの場合は、destroyアクションを介さず、直接DBのレコードを削除するため、
Reviewモデルの小モデルに当たるTaskモデルの外部キー制約に引っかかり、エラーが発生したためです。

## 備考（実装にあたって参考にした情報など）
- [Active Record の関連付け（4.1.2.4 :dependent）](https://railsguides.jp/association_basics.html#belongs-to%E3%81%AE%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3-dependent)