### PR TITLE
Dockerイメージの軽量化

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,31 +1,38 @@
-FROM ruby:2.5.1
+FROM ruby:2.6.5-alpine3.10
 
 ENV LANG C.UTF-8
-
-RUN apt-get update && apt-get install -y \
-    --no-install-recommends \
-    build-essential \
-    vim
-
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
-  && apt-get install -y nodejs \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /myapp
-
 COPY Gemfile /myapp/Gemfile
 COPY Gemfile.lock /myapp/Gemfile.lock
 
+RUN apk upgrade --no-cache && \
+    apk add --update --no-cache \
+      imagemagick6-dev \
+      mariadb-dev \
+      nodejs \
+      tzdata  \
+      yarn && \
+    apk add --update --no-cache --virtual=build-dependencies \
+      build-base \
+      curl-dev \
+      linux-headers \
+      libxml2-dev \
+      libxslt-dev \
+      ruby-dev \
+      yaml-dev \
+      zlib-dev && \
+    gem install bundler && \
+    bundle install -j4 && \
+    apk del build-dependencies && \
+    rm -rf /usr/local/bundle/cache/* \  
+    /usr/local/share/.cache/* \
+    /var/cache/* \
+    /tmp/* \
+    /usr/lib/mysqld* \
+    /usr/bin/mysql*
+
 RUN mkdir -p tmp/sockets
-
-RUN bundle install
 COPY . /myapp
-
-# Add a script to be executed every time the container starts.
-COPY entrypoint.sh /usr/bin/
-RUN chmod +x /usr/bin/entrypoint.sh
-ENTRYPOINT ["entrypoint.sh"]
 
 EXPOSE 3000
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.1'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
 # Use mysql as the database for Active Record

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: 'Dockerfile.dev'
     container_name: my_rails_app
     command: 
-      /bin/bash -c 'rm -rf tmp/pids/server.pid; bundle exec rails s -b 0.0.0.0'
+      /bin/sh -c 'rm -rf tmp/pids/server.pid; bundle exec rails s -b 0.0.0.0'
     environment:
       TZ: "Asia/Tokyo"
     ports:


### PR DESCRIPTION
## What
Dockerfileを書き換え、Dockerイメージを軽量化しました。
1.66GBから454MBへの軽量化に成功しました。

## Why
軽量化することにより、ビルド時の時間を短縮するため。
今後、AWS（ECR）にイメージを保管する際、料金の発生を最小限に防ぐため。

## How
- alpineベースのイメージを使用
- RUNコマンド実行時、`\ ` と`&&`でつなぐことにより、不要なレイヤーを増やさないように対応
- bundle installにしか必要ないライブラリは、実行後に削除
- 不要なキャッシュを削除

## 今回保留した作業と今後のTODO
- 余裕があれば、Dockerfileのマルチステージビルドにも挑戦する

## 備考（実装にあたって参考にした情報など）
- [お前のDockerイメージはまだ重い💢💢💢 - Speaker Deck](https://speakerdeck.com/stormcat24/oqian-falsedockerimezihamadazhong-i?slide=27)
-  [Alpine Linuxで素のRailsが動くDockerfile を作った - kasei_sanのブログ](https://blog.kasei-san.com/entry/2018/03/11/002752?utm_source=feed)
- [alpineベースのdockerイメージでrailsを動かすまで - Qiita](https://qiita.com/rh_taro/items/e2b4a0da4b7975921ff7)
- [RailsのDockerイメージを一番小さくする方法 - Qiita](https://qiita.com/baban/items/99877f9b3065c4cf3d50)
- [alpine linux+Dockerでmysqlを使用したアプリを作る際に気をつけたいこと - Qiita](https://qiita.com/celeron1ghz/items/a5f5e6932b666f425a07)
