### PR TITLE
imagemagickのバージョン修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY Gemfile.lock /myapp/Gemfile.lock
 
 RUN apk upgrade --no-cache && \
     apk add --update --no-cache \
-      imagemagick6-dev \
+      imagemagick6 \
       mariadb-dev \
       nodejs \
       tzdata  \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,7 +7,7 @@ COPY Gemfile.lock /myapp/Gemfile.lock
 
 RUN apk upgrade --no-cache && \
     apk add --update --no-cache \
-      imagemagick6-dev \
+      imagemagick \
       mariadb-dev \
       nodejs \
       tzdata  \


### PR DESCRIPTION
## What
alpineイメージにインストールするimagemagickのバージョンを修正しました。

## Why
ユーザーがアバターを登録しようとした際、以下のエラーが出て登録できない状態になっていたため。
`.mini_magick_processing_error`
- イシュー[#88](https://github.com/t-krt/ActiveReader/issues/88)
