### PR TITLE
マイページの読書状況ボタンのデザインを修正

### DIFF
--- a/app/assets/stylesheets/_share.scss
+++ b/app/assets/stylesheets/_share.scss
@@ -18,14 +18,12 @@ body {
 .btn-status {
   text-decoration: none;
   border-bottom: solid 6px gray;
-  border-radius: 3px;
   font-size: 0.9rem !important;
   margin-bottom: 25px;
+  opacity: 0.7;
+  box-shadow: inset 0 2px 0 rgba(255,255,255,0.2), inset 0 -2px 0 rgba(0, 0, 0, 0.05);
   &__active {
-    -webkit-transform: translateY(2.5px);
-    transform: translateY(2.5px);/*下に動く*/
-    box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.9);/*影を小さく*/
-    border-bottom: none;
+    opacity: 1;
   }
 }
 
@@ -106,3 +104,4 @@ body {
     width: auto;
   }
 }
+

--- a/app/assets/stylesheets/_share.scss
+++ b/app/assets/stylesheets/_share.scss
@@ -105,3 +105,13 @@ body {
   }
 }
 
+.heading {
+  font-size: 1.2rem;
+  font-weight: bold;
+  text-align: center;
+  padding: 0.4em 0.5em;/*文字の上下 左右の余白*/
+  color: #494949;/*文字色*/
+  background: #f4f4f4;/*背景色*/
+  border-left: solid 5px #7db4e6;/*左線*/
+  border-bottom: solid 3px #d7d7d7;/*下線*/
+}

--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -44,13 +44,6 @@
   vertical-align: middle;
 }
 
-.task-card-title {
-  font-size: 1.2rem;
-  font-weight: bold;
-  text-align: center;
-  margin-bottom: 0.8rem;
-}
-
 .task-table {
   &__left {
     width: 15%;

--- a/app/views/users/_heading.html.haml
+++ b/app/views/users/_heading.html.haml
@@ -1,0 +1,4 @@
+.heading
+  .span
+    %i.fas.fa-book
+    = "#{@user.nickname} さんの本棚"

--- a/app/views/users/read.html.haml
+++ b/app/views/users/read.html.haml
@@ -2,10 +2,9 @@
   .container.px-0
     .row.col-12.col-lg-10.mx-auto.p-0
       .main-content.col-11.col-sm-8.col-md-9.m-0.order-sm-2.mx-auto
+        = render "heading"
         .card
-          .card-header.bg-secondary.text-white
-            = "#{@user.nickname} さんの本棚"
-          .btn-group.d-flex{"aria-label":"読書状況"}
+          .btn-group.d-flex.p-0{"aria-label":"読書状況"}
             = link_to "読書中", reading_user_path, class: "btn btn-primary w-100 btn-status"
             = link_to "読了", read_user_path, class: "btn btn-success w-100 btn-status btn-status__active"
             = link_to "あとで読む", stock_user_path, class: "btn btn-danger w-100 btn-status"

--- a/app/views/users/read.html.haml
+++ b/app/views/users/read.html.haml
@@ -6,7 +6,9 @@
         .card
           .btn-group.d-flex.p-0{"aria-label":"読書状況"}
             = link_to "読書中", reading_user_path, class: "btn btn-primary w-100 btn-status"
-            = link_to "読了", read_user_path, class: "btn btn-success w-100 btn-status btn-status__active"
+            = link_to read_user_path, class: "btn btn-success w-100 btn-status btn-status__active" do
+              %i.fa.fa-caret-right
+              読了
             = link_to "あとで読む", stock_user_path, class: "btn btn-danger w-100 btn-status"
           - if @reads.present?
             .container

--- a/app/views/users/reading.html.haml
+++ b/app/views/users/reading.html.haml
@@ -5,7 +5,9 @@
         = render "heading"
         .card
           .btn-group.d-flex.p-0{"aria-label":"読書状況"}
-            = link_to "読書中", reading_user_path, class: "btn btn-primary w-100 btn-status btn-status__active"
+            = link_to reading_user_path, class: "btn btn-primary w-100 btn-status btn-status__active" do
+              %i.fa.fa-caret-right
+              読書中 
             = link_to "読了", read_user_path, class: "btn btn-success w-100 btn-status"
             = link_to "あとで読む", stock_user_path, class: "btn btn-danger w-100 btn-status"
           - if @reading.present?

--- a/app/views/users/reading.html.haml
+++ b/app/views/users/reading.html.haml
@@ -2,10 +2,9 @@
   .container.px-0
     .row.col-12.col-lg-10.mx-auto.p-0
       .main-content.col-11.col-sm-8.col-md-9.m-0.order-sm-2.mx-auto
+        = render "heading"
         .card
-          .card-header.bg-secondary.text-white
-            = "#{@user.nickname} さんの本棚"
-          .btn-group.d-flex{"aria-label":"読書状況"}
+          .btn-group.d-flex.p-0{"aria-label":"読書状況"}
             = link_to "読書中", reading_user_path, class: "btn btn-primary w-100 btn-status btn-status__active"
             = link_to "読了", read_user_path, class: "btn btn-success w-100 btn-status"
             = link_to "あとで読む", stock_user_path, class: "btn btn-danger w-100 btn-status"

--- a/app/views/users/stock.html.haml
+++ b/app/views/users/stock.html.haml
@@ -2,10 +2,9 @@
   .container.px-0
     .row.col-12.col-lg-10.mx-auto.p-0
       .main-content.col-11.col-sm-8.col-md-9.m-0.order-sm-2.mx-auto
+        = render "heading"
         .card
-          .card-header.bg-secondary.text-white
-            = "#{@user.nickname} さんの本棚"
-          .btn-group.d-flex{"aria-label":"読書状況"}
+          .btn-group.d-flex.p-0{"aria-label":"読書状況"}
             = link_to "読書中", reading_user_path, class: "btn btn-primary w-100 btn-status"
             = link_to "読了", read_user_path, class: "btn btn-success w-100 btn-status"
             = link_to "あとで読む", stock_user_path, class: "btn btn-danger w-100 btn-status  btn-status__active"

--- a/app/views/users/stock.html.haml
+++ b/app/views/users/stock.html.haml
@@ -7,7 +7,9 @@
           .btn-group.d-flex.p-0{"aria-label":"読書状況"}
             = link_to "読書中", reading_user_path, class: "btn btn-primary w-100 btn-status"
             = link_to "読了", read_user_path, class: "btn btn-success w-100 btn-status"
-            = link_to "あとで読む", stock_user_path, class: "btn btn-danger w-100 btn-status  btn-status__active"
+            = link_to stock_user_path, class: "btn btn-danger w-100 btn-status  btn-status__active" do
+              %i.fa.fa-caret-right
+              あとで読む
           - if @stocks.present?
             .container
               .row


### PR DESCRIPTION
## What
マイページの読書状況のデザインを修正しました。

## Why
ユーザーが自分が今どこのページにいるかを認識しやすくするため。

## How
- 現在選択していないボタンについては、opacityプロパティを利用し、透明度を高くしました。
- 選択中であることを示すアイコンを付けることで、他の状況と区別しやすくしました。
- あわせて見出しのデザインを調整しました。

## 今後のTodo
- 他のページの見出し等について、同様に修正する。

## 備考（実装にあたって参考にした情報など）
- [CSSで作る！押したくなるボタンデザイン100（Web用）](https://saruwakakun.com/html-css/reference/buttons)

## 実装画面・機能のキャプチャ
- [変更前のビュー](https://gyazo.com/c581947c7d3ca6de8fbba2292658693c)
- [変更後のビュー](https://gyazo.com/bc597bc92d67e2c0fccc95d7425d6588)
